### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/text-latin1.cabal
+++ b/text-latin1.cabal
@@ -34,9 +34,10 @@ Library
                , data-checked >= 0.2
                , bytestring
                , text
-               , semigroups >= 0.18.4
                , case-insensitive >= 1.0
                , hashable >= 1.1
+  if impl(ghc < 8.0)
+    Build-Depends: semigroups >= 0.18.4
   Hs-Source-Dirs: src
   GHC-Options: -Wall
   Exposed-Modules:


### PR DESCRIPTION
They are not needed on newer GHC.